### PR TITLE
Fix mistyping in cleanup

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -130,9 +130,9 @@ dtls_InitServer(DTLSParams* params)
 }
 
 void
-dtls_Shutdown(DTLSParams* k)
+dtls_Shutdown(DTLSParams* params)
 {
-    if (k == NULL) {
+    if (params == NULL) {
         return;
     }
 


### PR DESCRIPTION
dtls_Shutdown was declared with parameter 'DTLSParams* k', but in body used parameter 'params'