### PR TITLE
Depress openssl warnings on deprecated methods

### DIFF
--- a/dtls.c
+++ b/dtls.c
@@ -68,7 +68,7 @@ dtls_InitContextFromKeystore(DTLSParams* params, const char* keyname)
     int result = 0;
 
     // Create a new context using DTLS
-    params->ctx = SSL_CTX_new(DTLSv1_method());
+    params->ctx = SSL_CTX_new(DTLS_method());
     if (params->ctx == NULL) {
         printf("Error: cannot create SSL_CTX.\n");
         ERR_print_errors_fp(stderr);


### PR DESCRIPTION
See also
- pull request PR https://github.com/liuqun/dtls-test/issues/1
- `https://github.com/warmcat/libwebsockets/issues/186`