### PR TITLE
Prevent returning garbage to the client.

### DIFF
--- a/dtls_server.c
+++ b/dtls_server.c
@@ -90,7 +90,7 @@ main()
                 printf("\n");
 
                 // Echo the message back to the client
-                SSL_write(server.ssl, outbuf, sizeof(outbuf));
+                SSL_write(server.ssl, outbuf, read);
             }
         }
 


### PR DESCRIPTION
To prevent returning garbage to the client, you need to use the size of the data received with SSL_write. 